### PR TITLE
update go-to-top default delay to 4s. 3.5s was a tiny smidge too shor…

### DIFF
--- a/packages/@cagov/go-to-top/ROADMAP.md
+++ b/packages/@cagov/go-to-top/ROADMAP.md
@@ -11,5 +11,5 @@
 * Button appears when hitting the bottom of the page.
 * Button appears on scrolling up.
 * Button appears after scrolling past 400px.
-* Button disappears after inactivity for 3.5 seconds.
+* Button disappears after inactivity for 4 seconds.
 * Label updates from data-attribute

--- a/packages/@cagov/go-to-top/package.json
+++ b/packages/@cagov/go-to-top/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cagov/go-to-top",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/packages/@cagov/go-to-top/src/index.js
+++ b/packages/@cagov/go-to-top/src/index.js
@@ -8,7 +8,7 @@ export class CaGovGoToTop extends window.HTMLElement {
       styles: "button-blue",
       label: "Top",
       scrollAfterHeight: 400,
-      removeAfter: 3500,
+      removeAfter: 4000,
       scrollBottomThreshold: 10,
     };
     this.state = {


### PR DESCRIPTION
…t still. Future version will let this be a data attribute. We will need more robust attribute type checking for our web components and need to build that capacity so that the inputs are very reliable and hard to break.